### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yet Another Syntax Highlighter
 
-This is yet an another syntax highlighter for lex/yacc and flex/bison.
+This is yet another syntax highlighter for lex/yacc and flex/bison.
 
 ## Features
 


### PR DESCRIPTION
Probably unintended ‘an’ before ‘another’