### PR TITLE
Fix syntax highlighting of embedded Java

### DIFF
--- a/syntaxes/lex.tmLanguage.json
+++ b/syntaxes/lex.tmLanguage.json
@@ -307,6 +307,9 @@
 		"embedded": {
 			"patterns": [
 				{
+					"include": "source.java"
+				},
+				{
 					"include": "source.cpp"
 				},
 				{

--- a/syntaxes/yacc.tmLanguage.json
+++ b/syntaxes/yacc.tmLanguage.json
@@ -354,6 +354,9 @@
 		"embedded": {
 			"patterns": [
 				{
+					"include": "source.java"
+				},
+				{
 					"include": "source.cpp"
 				},
 				{


### PR DESCRIPTION
Example grammar using JFlex and Bison: https://github.com/valecor95/bison-flex-jflex-examples/tree/master/Java/0_MyGrammar