### PR TITLE
Add "require" as a keyword for yacc

### DIFF
--- a/src/languages/services/yaccCompletions.ts
+++ b/src/languages/services/yaccCompletions.ts
@@ -5,7 +5,8 @@ import { TokenType } from '../yaccLanguageTypes';
 
 const keywords = ['type', 'token', 'option', 'token-table', 'left', 'right', 'define', 'output',
     'precedence', 'nterm', 'destructor', 'union', 'code', 'printer', 'defines', 'start', 'skeleton', 'glr-parser', 'language',
-    'parse-param', 'lex-param', 'pure-parser', 'expect', 'expect-rr', 'name-prefix', 'locations', 'nonassoc'];
+    'parse-param', 'lex-param', 'pure-parser', 'expect', 'expect-rr', 'name-prefix', 'locations', 'nonassoc', 'debug',
+    'file-prefix', 'header', 'no-lines', 'require', 'verbose', 'yacc'];
 
 export function doYACCComplete(document: TextDocument, position: Position, yaccDocument: YACCDocument): CompletionItem[] | CompletionList {
     const offset = document.offsetAt(position);

--- a/syntaxes/yacc.tmLanguage.json
+++ b/syntaxes/yacc.tmLanguage.json
@@ -111,7 +111,7 @@
 			]
 		},
 		"keywords": {
-			"begin": "^%(option|token-table|token(?=(\\s|<))|expect-rr|expect|nonassoc(?=\\s)|left(?=\\s)|right(?=\\s)|defines|output|precedence|nterm|start|name-prefix|locations|skeleton|glr-parser|language|pure-parser)",
+			"begin": "^%(option|token-table|token(?=(\\s|<))|expect-rr|expect|nonassoc(?=\\s)|left(?=\\s)|right(?=\\s)|defines|output|precedence|nterm|start|name-prefix|locations|skeleton|glr-parser|language|pure-parser|debug|file-prefix|header|no-lines|require|verbose|yacc)",
 			"end": "(?=%)",
 			"beginCaptures": {
 				"0": {


### PR DESCRIPTION
Thanks for the work on this extension, I find it very useful.

Small addition to add "require" as a keyword for yacc files.
https://www.gnu.org/software/bison/manual/bison.html#index-_0025require-2