### PR TITLE
Various fixes to better support doxygen's lexer files

### DIFF
--- a/src/languages/lexLanguageTypes.ts
+++ b/src/languages/lexLanguageTypes.ts
@@ -24,6 +24,7 @@ export enum TokenType {
     Unknown,
     Divider,
     Escape,
+    CharRange,
     EOL,
     EOS
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -66,5 +66,5 @@ export function runSafe<T>(func: () => T, errorVal: T, errorMessage: string, tok
 
 function cancelValue<E>() {
     console.log("Request cancelled...");
-    return undefined;
+    return undefined as unknown as E;
 }

--- a/syntaxes/lex.tmLanguage.json
+++ b/syntaxes/lex.tmLanguage.json
@@ -34,6 +34,9 @@
 					"include": "#comments"
 				},
 				{
+					"include": "#comment"
+				},
+				{
 					"include": "#strings"
 				}
 			]
@@ -57,6 +60,9 @@
 					"patterns": [
 						{
 							"include": "#comments"
+						},
+						{
+							"include": "#comment"
 						},
 						{
 							"include": "#brackets"
@@ -178,7 +184,7 @@
 		},
 		"startcondition_block": {
 				"name": "entity.startcondition.lex",
-				"begin": "<[a-zA-Z0-9_,]+>[ ]*{(?=$)",
+				"begin": "<[a-zA-Z0-9_,]+>\\s*{\\s*(?=($|//|/\\*))",
 				"end": "^}",
 				"beginCaptures": {
 					"0": {
@@ -195,6 +201,9 @@
 						"include": "#comments"
 					},
 					{
+						"include": "#comment"
+					},
+ 					{
 						"include": "#strings"
 					},
 					{
@@ -248,6 +257,9 @@
 					"include": "#comments"
 				},
 				{
+					"include": "#comment"
+				},
+				{
 					"name": "constant.numeric.lex",
 					"match": "."
 				}
@@ -264,6 +276,9 @@
 			"patterns": [
 				{
 					"include": "#comments"
+				},
+				{
+					"include": "#comment"
 				},
 				{
 					"include": "#user-define"
@@ -318,6 +333,11 @@
 			"name": "comment.block.yacc",
 			"begin": "/\\*",
 			"end": "\\*/"
+		},
+		"comment": {
+			"name": "comment.single.yacc",
+			"begin": "//",
+			"end": "$"
 		}
 	},
 	"scopeName": "source.l"


### PR DESCRIPTION
Thanks for the nice VSCode plugin.

While testing it on Doxygen's [lexer files](https://github.com/doxygen/doxygen/tree/master/src), I ran into a couple of small issues, and decided to dive into the code and try to fix them.

Here is the list of fixes:
- Prevent `<`,`>`,`{`,`}` characters inside character ranges from breaking the scanner.
- Allow `TokenType.Action` also in `WaitingAction` state.
- Allow comments in definition section and condition blocks.
- Allow comments at more places in the syntax highlighting.
- Fix compile issue with undefined in `changeValue<E>()`.

