### PR TITLE
Added support for C++ variants for api.value.type

### DIFF
--- a/src/languages/parser/utils.ts
+++ b/src/languages/parser/utils.ts
@@ -39,6 +39,7 @@ export const _SBO = '['.charCodeAt(0);
 export const _SBC = ']'.charCodeAt(0);
 export const _SCL = ';'.charCodeAt(0);
 export const _AND = '&'.charCodeAt(0);
+export const _COM = ','.charCodeAt(0);
 
 /**
  * Imported from Microsoft's vscode-html-languageservice's scanner.

--- a/src/languages/parser/yaccScanner.ts
+++ b/src/languages/parser/yaccScanner.ts
@@ -1,7 +1,7 @@
 import { TokenType, ScannerState, Scanner } from '../yaccLanguageTypes'
 
 import {
-    MultiLineStream, _FSL, _AST, _NWL, _BAR, _COL, _BOP, _BCL, _DOT, _PCS, _LAN, _DQO, _SQO, _RAN, _SBO, _SCL
+    MultiLineStream, _FSL, _AST, _NWL, _BAR, _COL, _BOP, _BCL, _DOT, _PCS, _LAN, _DQO, _SQO, _RAN, _SBO, _SCL, _COM
 } from './utils'
 
 export function createScanner(input: string, initialOffset = 0, initialState: ScannerState = ScannerState.WithinContent): Scanner {
@@ -15,6 +15,35 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
         // return stream.advanceIfRegExp(/^[a-zA-Z][\w.]*/);
         return stream.advanceIfRegExp(/^[a-zA-Z][\w.-]*/);  // gnu bison extension allows the dash symbol
     }
+
+    function nextType(): string {
+        // Allow C++ types like std::string, std::vector<int>, etc.
+        let typeName = stream.advanceIfRegExp(/^[a-zA-Z][\w.-:]*/);
+    
+        stream.skipWhitespace?.();
+    
+        if (stream.advanceIfChar(_LAN)) { // '<'
+            typeName += '<';
+            stream.skipWhitespace?.();
+            typeName += nextType();
+    
+            for (;;) {
+                stream.skipWhitespace?.();
+                if (!stream.advanceIfChar(_COM)) break;
+                typeName += ',';
+                stream.skipWhitespace?.();
+                typeName += nextType();
+            }
+    
+            stream.skipWhitespace?.();
+            if (stream.advanceIfChar(_RAN)) { // '>'
+                typeName += '>';
+            }
+        }
+    
+        return typeName;
+    }
+    
 
     function nextLiteral(): string {
         return stream.advanceIfRegExp(/^("(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*')/);
@@ -89,6 +118,11 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
                         }
 
                         if (stream.advanceIfRegExp(/^[\w-]+/)) {
+                            if (stream.getSource().substring(offset, stream.pos()).toLowerCase() === '%define') {
+                                // We have a define; we return the ENTIRE line up to (but not including) the newline
+                                stream.advanceUntilChar(_NWL);
+                                return finishToken(offset, TokenType.Definition);
+                            }
                             return finishToken(offset, TokenType.Option);
                         }
                         return finishToken(offset, TokenType.Percent);
@@ -136,7 +170,7 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
                     return finishToken(offset, TokenType.EndType);
                 }
 
-                const typeValue = nextWord();
+                const typeValue = nextType();
                 if (typeValue.length > 0) {
                     return finishToken(offset, TokenType.TypeValue);
                 }

--- a/src/languages/parser/yaccScanner.ts
+++ b/src/languages/parser/yaccScanner.ts
@@ -18,7 +18,7 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
 
     function nextType(): string {
         // Allow C++ types like std::string, std::vector<int>, etc.
-        let typeName = stream.advanceIfRegExp(/^[a-zA-Z][\w.-:]*/);
+        let typeName = stream.advanceIfRegExp(/^[a-zA-Z][\w\*.-:]*/);
     
         stream.skipWhitespace?.();
     

--- a/src/languages/yaccLanguageTypes.ts
+++ b/src/languages/yaccLanguageTypes.ts
@@ -16,6 +16,7 @@ export enum TokenType {
     StartComment,
     EndComment,
     Comment,
+    Definition,
     StartAction,
     EndAction,
     Action,


### PR DESCRIPTION
This adds support for C++ variants for the api.value.type and closes issue https://github.com/babyraging/yash/issues/26.

Rather than add additional parsing states to the parser for parsing definition lines, I simply passed those lines in their entirety from the lexer as a big single token for the entire line. That is then parsed with a simple regex in the parser. It's quick and dirty, but kept the changes to a minimum. Then the parser stores the definitions in a dict.

I also had to add support for C++ types inside of <> rather than just simple identifiers. That means complete template names with nested <>'s, as well as colons. The code for this may not be extremely robust (it doesn't allow things like /**/ comments inside the types, for example) but works for me.