### PR TITLE
Decorate production components with numbers & provide hover support over $n/$$ references in actions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { newSemanticTokenProvider } from './modes/semanticProvider';
 import { getLanguageModes } from './modes/languageModes';
 import { runSafe } from './runner';
+import { decorateComponentNumbers } from './languages/yaccComponentNumbers';
 const pendingValidationRequests: { [uri: string]: NodeJS.Timer } = {};
 const validationDelayMs = 500;
 
@@ -151,4 +152,12 @@ async function validateTextDocument(document: vscode.TextDocument, force?: boole
 	}
 	diagnostics.set(document.uri, mode.doValidation(document, force));
 	configurationChanged = false;
+
+	if (document.languageId === 'yacc' && typeof mode.getParsedDocument === 'function') {
+		const yaccDoc = mode.getParsedDocument(document);
+		const editor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find((e: vscode.TextEditor) => e.document === document);
+		if (editor && yaccDoc) {
+			decorateComponentNumbers(editor, yaccDoc);
+		}
+	}
 }

--- a/src/languages/parser/yaccParser.ts
+++ b/src/languages/parser/yaccParser.ts
@@ -455,6 +455,19 @@ export function parse(text: string): YACCDocument {
             case TokenType.Bar:
                 if (state !== ParserState.WaitingRule) {
                     addProblem(`Unexpected | symbol.`, scanner.getTokenOffset(), scanner.getTokenEnd(), ProblemType.Error);
+                } else {
+                    // Record production boundary so that the ComponetNumber decorations can separate alternative productions
+                    document.components.push({
+                        terminal: true,
+                        offset: offset,
+                        length: scanner.getTokenLength(),
+                        end: scanner.getTokenEnd(),
+                        name: '|',
+                        type: '',
+                        used: true,
+                        definition: [-1, -1],
+                        references: [[offset, scanner.getTokenEnd()]]
+                    });
                 }
                 break;
             default:
@@ -471,6 +484,9 @@ export function parse(text: string): YACCDocument {
 
     for (let i = 0; i < document.components.length; i++) {
         const component = document.components[i];
+        if (component.name === '|') {
+            continue;
+        }
         let symbol: ISymbol;
         if ((symbol = document.symbols[component.name])) {
             component.terminal = false;

--- a/src/languages/parser/yaccParser.ts
+++ b/src/languages/parser/yaccParser.ts
@@ -456,7 +456,7 @@ export function parse(text: string): YACCDocument {
                 if (state !== ParserState.WaitingRule) {
                     addProblem(`Unexpected | symbol.`, scanner.getTokenOffset(), scanner.getTokenEnd(), ProblemType.Error);
                 } else {
-                    // Record production boundary so that the ComponetNumber decorations can separate alternative productions
+                    // Record production boundary so that the ComponentNumber decorations can separate alternative productions
                     document.components.push({
                         terminal: true,
                         offset: offset,

--- a/src/languages/services/yaccHover.ts
+++ b/src/languages/services/yaccHover.ts
@@ -1,12 +1,111 @@
-import { TextDocument, Hover, Position, MarkdownString, workspace } from 'vscode';
-import { YACCDocument, ISymbol, predefined } from '../parser/yaccParser';
+import { TextDocument, Hover, Position, MarkdownString, workspace, Range } from 'vscode';
+import { YACCDocument, ISymbol, predefined, NodeType, Node } from '../parser/yaccParser';
 import { createMarkedCodeString } from './utils';
+
+function getDollarRefAt(document: TextDocument, position: Position): { text: string; range: Range } | null {
+    const line = document.lineAt(position.line).text;
+    const i = position.character;
+
+    // Match $$ or $123 anywhere on the line and pick the one under the cursor.
+    const re = /\$\$|\$\d+/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(line)) !== null) {
+        const start = m.index;
+        const end = start + m[0].length;
+        if (i >= start && i <= end) {
+            return {
+                text: m[0],
+                range: new Range(new Position(position.line, start), new Position(position.line, end))
+            };
+        }
+    }
+    return null;
+}
+
+function findEnclosingRule(yaccDocument: YACCDocument, offset: number): Node | undefined {
+    // Smallest Rule node containing the offset.
+    let best: Node | undefined;
+    for (const n of yaccDocument.nodes) {
+        if (n.nodeType !== NodeType.Rule) continue;
+        if (offset < n.offset || offset > n.end) continue;
+        if (!best || (n.end - n.offset) < (best.end - best.offset)) best = n;
+    }
+    return best;
+}
+
+function resolveComponentNameForDollarRef(
+    yaccDocument: YACCDocument,
+    rule: Node,
+    embeddedOffset: number,
+    embeddedEnd: number,
+    n: number
+): string | null {
+    if (n <= 0) return null;
+
+    const compsInRule = yaccDocument.components
+        .filter(c => c.offset >= rule.offset && c.end <= rule.end)
+        .sort((a, b) => a.offset - b.offset);
+
+    // Determine which alternative we are in by looking for the nearest '|' before this action (if present),
+    // and the next '|' after it (if present).
+    let startBound = rule.offset;
+    for (let i = 0; i < compsInRule.length; i++) {
+        const c = compsInRule[i];
+        if (c.name === '|' && c.offset < embeddedOffset) {
+            startBound = c.end; // start after bar
+        }
+    }
+
+    let endBound = rule.end;
+    for (let i = 0; i < compsInRule.length; i++) {
+        const c = compsInRule[i];
+        if (c.name === '|' && c.offset >= embeddedEnd) {
+            endBound = c.offset; // end before next bar
+            break;
+        }
+    }
+
+    const prod = compsInRule
+        .filter(c => c.name !== '|' && c.offset >= startBound && c.end <= endBound)
+        .sort((a, b) => a.offset - b.offset);
+
+    const target = prod[n - 1];
+    return target ? target.name : null;
+}
 
 export function doYACCHover(document: TextDocument, position: Position, yaccDocument: YACCDocument): Hover | null {
     const offset = document.offsetAt(position);
-    const code = yaccDocument.getEmbeddedNode(offset);
-    if (code) {
-        return null;
+
+    // Provide hover for $n/$$ inside actions.
+    const embedded = yaccDocument.getEmbeddedNode(offset);
+    if (embedded) {
+        const ref = getDollarRefAt(document, position);
+        if (!ref) {
+            return null;
+        }
+
+        const rule = findEnclosingRule(yaccDocument, offset);
+        if (!rule) {
+            return null;
+        }
+
+        // $$ refers to the LHS non-terminal of the enclosing rule.
+        if (ref.text === '$$') {
+            if (!rule.name) return null;
+            return { contents: [createMarkedCodeString(`${ref.text} → ${rule.name}`, 'yacc')] };
+        }
+
+        const n = Number.parseInt(ref.text.slice(1), 10);
+        if (!Number.isFinite(n)) {
+            return null;
+        }
+
+        const name = resolveComponentNameForDollarRef(yaccDocument, rule, embedded.offset, embedded.end, n);
+        if (!name) {
+            return null;
+        }
+
+        return { contents: [createMarkedCodeString(`${ref.text} → ${name}`, 'yacc')] };
     }
 
     var symbol: ISymbol;

--- a/src/languages/yaccComponentNumbers.ts
+++ b/src/languages/yaccComponentNumbers.ts
@@ -1,7 +1,74 @@
 import * as vscode from 'vscode';
 import { YACCDocument, NodeType } from './parser/yaccParser';
+import { createScanner } from './parser/yaccScanner';
+import { TokenType } from './yaccLanguageTypes';
 
 const componentNumberDecorationType = vscode.window.createTextEditorDecorationType({});
+
+function buildDollarIndexByOffset(
+    text: string,
+    ruleOffset: number,
+    ruleEnd: number,
+    // Offsets of RHS components (from the parser) that are eligible to be numbered.
+    componentOffsets: ReadonlySet<number>
+): Map<number, number> {
+    const scanner = createScanner(text, ruleOffset);
+    const map = new Map<number, number>();
+
+    let count = 1;
+    let skipNext = false;
+
+    for (;;) {
+        const tok = scanner.scan();
+        const off = scanner.getTokenOffset();
+        if (tok === TokenType.EOS || off >= ruleEnd) break;
+
+        switch (tok) {
+            case TokenType.Bar:
+                count = 1;
+                skipNext = false;
+                break;
+
+            case TokenType.StartAction:
+            case TokenType.Action:
+            case TokenType.EndAction:
+                // Actions do not contribute to $n numbering.
+                break;
+
+            case TokenType.Option: {
+                const opt = scanner.getTokenText().toLowerCase();
+                // These directives take an argument that is not a RHS component.
+                if (opt === '%prec' || opt === '%dprec' || opt === '%merge') {
+                    skipNext = true;
+                }
+                break;
+            }
+
+            case TokenType.Word:
+            case TokenType.Literal: {
+                // Only number tokens that correspond to parsed RHS components.
+                // Don't count the LHS or other non-component words.
+                const isComponent = componentOffsets.has(off);
+
+                if (skipNext) {
+                    // Skip the directive argument (e.g. SOME_PRECEDENCE after %prec)
+                    skipNext = false;
+                    break;
+                }
+
+                if (isComponent) {
+                    map.set(off, count++);
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    return map;
+}
 
 export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YACCDocument) {
     if (editor.document.languageId !== 'yacc') {
@@ -10,6 +77,7 @@ export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YAC
         return;
     }
 
+    const text = editor.document.getText();
     const decorations: vscode.DecorationOptions[] = [];
 
     for (const node of yaccDoc.nodes) {
@@ -19,12 +87,20 @@ export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YAC
             .filter(c => c.offset >= node.offset && c.end <= node.end)
             .sort((a, b) => a.offset - b.offset);
 
-        let count = 1;
+        // Offsets for actual RHS components we might decorate.
+        const componentOffsets = new Set<number>(
+            rhsComponents
+                .filter(c => c.name !== '|')
+                .map(c => c.offset)
+        );
+
+        const dollarIndexByOffset = buildDollarIndexByOffset(text, node.offset, node.end, componentOffsets);
+
         for (const comp of rhsComponents) {
-            if (comp.name === '|') {
-                count = 1;
-                continue;
-            }
+            if (comp.name === '|') continue;
+
+            const n = dollarIndexByOffset.get(comp.offset);
+            if (!n) continue; // skips %prec arg, etc.
 
             decorations.push({
                 range: new vscode.Range(
@@ -33,7 +109,7 @@ export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YAC
                 ),
                 renderOptions: {
                     before: {
-                        contentText: `\$${count++}:`,
+                        contentText: `\$${n}:`,
                         color: '#888',
                         margin: '0 3px 0 0'
                     }

--- a/src/languages/yaccComponentNumbers.ts
+++ b/src/languages/yaccComponentNumbers.ts
@@ -1,18 +1,23 @@
 import * as vscode from 'vscode';
 import { YACCDocument, NodeType } from './parser/yaccParser';
 
+const componentNumberDecorationType = vscode.window.createTextEditorDecorationType({});
+
 export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YACCDocument) {
-    if (editor.document.languageId !== 'yacc') return;
+    if (editor.document.languageId !== 'yacc') {
+        // Clear any old decorations if this editor is not yacc anymore.
+        editor.setDecorations(componentNumberDecorationType, []);
+        return;
+    }
 
     const decorations: vscode.DecorationOptions[] = [];
-    const decoType = vscode.window.createTextEditorDecorationType({});
 
     for (const node of yaccDoc.nodes) {
         if (node.nodeType !== NodeType.Rule) continue;
 
         const rhsComponents = yaccDoc.components
             .filter(c => c.offset >= node.offset && c.end <= node.end)
-            .sort((a, b) => a.offset - b.offset); // be explicit
+            .sort((a, b) => a.offset - b.offset);
 
         let count = 1;
         for (const comp of rhsComponents) {
@@ -21,21 +26,21 @@ export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YAC
                 continue;
             }
 
-			decorations.push({
-				range: new vscode.Range(
-					editor.document.positionAt(comp.offset),
-					editor.document.positionAt(comp.offset)
-				),
-				renderOptions: {
-					before: {
-						contentText: `\$${count++}:`,
-						color: '#888',
-						margin: '0 3px 0 0'
-					}
-				}
-			});
+            decorations.push({
+                range: new vscode.Range(
+                    editor.document.positionAt(comp.offset),
+                    editor.document.positionAt(comp.offset)
+                ),
+                renderOptions: {
+                    before: {
+                        contentText: `\$${count++}:`,
+                        color: '#888',
+                        margin: '0 3px 0 0'
+                    }
+                }
+            });
         }
     }
 
-    editor.setDecorations(decoType, decorations);
+    editor.setDecorations(componentNumberDecorationType, decorations);
 }

--- a/src/languages/yaccComponentNumbers.ts
+++ b/src/languages/yaccComponentNumbers.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import { YACCDocument, NodeType } from './parser/yaccParser';
+
+export function decorateComponentNumbers(editor: vscode.TextEditor, yaccDoc: YACCDocument) {
+    if (editor.document.languageId !== 'yacc') return;
+
+    const decorations: vscode.DecorationOptions[] = [];
+    const decoType = vscode.window.createTextEditorDecorationType({});
+
+    for (const node of yaccDoc.nodes) {
+        if (node.nodeType !== NodeType.Rule) continue;
+
+        const rhsComponents = yaccDoc.components
+            .filter(c => c.offset >= node.offset && c.end <= node.end)
+            .sort((a, b) => a.offset - b.offset); // be explicit
+
+        let count = 1;
+        for (const comp of rhsComponents) {
+            if (comp.name === '|') {
+                count = 1;
+                continue;
+            }
+
+			decorations.push({
+				range: new vscode.Range(
+					editor.document.positionAt(comp.offset),
+					editor.document.positionAt(comp.offset)
+				),
+				renderOptions: {
+					before: {
+						contentText: `\$${count++}:`,
+						color: '#888',
+						margin: '0 3px 0 0'
+					}
+				}
+			});
+        }
+    }
+
+    editor.setDecorations(decoType, decorations);
+}

--- a/src/modes/languageModes.ts
+++ b/src/modes/languageModes.ts
@@ -46,6 +46,7 @@ export interface LanguageMode {
     // getFoldingRanges?: (document: TextDocument) => FoldingRange[];
     getSemanticTokens?(document: TextDocument): SemanticTokenData[];
     getSemanticTokenLegend?(): { types: string[], modifiers: string[] };
+    getParsedDocument?(document: TextDocument): any;
     onDocumentRemoved(document: TextDocument): void;
     dispose(): void;
 }

--- a/src/modes/yaccMode.ts
+++ b/src/modes/yaccMode.ts
@@ -50,6 +50,9 @@ export function getYACCMode(yaccLanguageService: YACCLanguageService): LanguageM
         getSemanticTokenLegend() {
             return { types: tokenTypes, modifiers: tokenModifiers };
         },
+        getParsedDocument(document: TextDocument): YACCDocument {
+            return cache.get(document);
+        },
         onDocumentRemoved(document: TextDocument) {
             cache.onDocumentRemoved(document);
         },


### PR DESCRIPTION
<img width="499" height="233" alt="yash-update-labels" src="https://github.com/user-attachments/assets/ffe5f338-cdfd-43b8-ab8c-1dd9603ad496" />

This change provides editor decorations for each component of a production, showing `$1:`, `$2:`, etc

<img width="508" height="235" alt="yash-update-hover" src="https://github.com/user-attachments/assets/d9e6bc6e-3b08-4616-9197-4942e5099a0b" />

It also provides hover information over `$n`/`$$` references inside the action body, displaying which production component is being referred to by this.

In order to accomplish this change:

 - The parse function now stores the separator bars in its components list so that these can be used to distinguish alternative productions for correct component numbering
 - A getParsedDocument method was added to the LanguageMode interface, so the already-parsed YaccDocument could be returned for use by the decoration function